### PR TITLE
Fix honeybadger config and make everything more concurrent

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,33 @@
 hash: 22a5adca736232f400c788e6d9263cae489daba4bc42a3214c710a016a639e9c
-updated: 2016-06-23T15:18:27.309622705-05:00
+updated: 2016-08-22T14:10:50.173940848-05:00
 imports:
 - name: github.com/honeybadger-io/honeybadger-go
   version: 36d30005a9a829178efbdf9a78e29edd136a569b
 - name: github.com/joho/godotenv
   version: 4ed13390c0acd2ff4e371e64d8b97c8954138243
+- name: github.com/pborman/uuid
+  version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/robfig/cron
-  version: 6f2e8282a1a0d694e55a48ce7d077ee46747feeb
+  version: ab4c16f3a09641bd19d65f55b3d8d6edda7a8e05
+- name: github.com/shirou/gopsutil
+  version: 2eb8f8bff811a958928698101422a0da22fa8e36
+  subpackages:
+  - load
+  - mem
+  - internal/common
 - name: github.com/wearemolecule/kubeclient
   version: 8e465a3c3da9b46782c14da57c141ab2a45ef467
 - name: golang.org/x/build
-  version: 89e8d00eafe6d6ccb39c01e2c75735161b9dcfaa
+  version: 1615165ba855199d66cb584764bb30f1439b02b1
   subpackages:
   - kubernetes/api
 - name: golang.org/x/net
-  version: bc3663df0ac92f928d419e31e0d2af22e683a5a2
+  version: 7394c112eae4dba7e96bfcfe738e6373d61772b4
   subpackages:
   - context
   - context/ctxhttp
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 devImports: []

--- a/kube-scheduler.go
+++ b/kube-scheduler.go
@@ -131,14 +131,13 @@ func (j Job) Equal(job Job) bool {
 	return j.Cron == job.Cron &&
 		j.Template == job.Template &&
 		j.Description == job.Description &&
-		j.Args == job.Args &&
 		j.Namespace == job.Namespace
 }
 
 func (j Job) Run() {
 	jobName, err := manager.NameFromJob(j)
 	if err != nil {
-		log.Printf()
+		log.Println(err)
 		return
 	}
 

--- a/kube-scheduler.go
+++ b/kube-scheduler.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	honeybadger "github.com/honeybadger-io/honeybadger-go"
@@ -22,7 +23,7 @@ import (
 
 var configDir string
 var kubeClient *kube.Client
-var jobLock map[string]string
+var manager Manager
 
 func init() {
 	flag.StringVar(&configDir, "dir", ".", "Directory where config is located")
@@ -32,7 +33,6 @@ func main() {
 	configureHoneybadger()
 	defer honeybadger.Monitor()
 
-	jobLock = make(map[string]string)
 	flag.Parse()
 	err := godotenv.Load()
 	if err != nil {
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		nErr := fmt.Errorf("Failed to connect to kubernetes. Error: %v", err)
 		honeybadger.Notify(nErr, honeybadger.Fingerprint{fmt.Sprintf("%d", time.Now().Unix())})
-		panic(nErr)
+		log.Fatal(nErr)
 	}
 
 	b, err := ioutil.ReadFile(filePath("schedule.yml"))
@@ -59,6 +59,12 @@ func main() {
 		nErr := fmt.Errorf("Unable to unmarshal schedule yaml, error: %v", err)
 		honeybadger.Notify(nErr, honeybadger.Fingerprint{fmt.Sprintf("%d", time.Now().Unix())})
 		log.Fatal(nErr)
+	}
+
+	manager = Manager{
+		config,
+		make(map[string]string),
+		&sync.Mutex{},
 	}
 
 	log.Println(config)
@@ -78,6 +84,41 @@ func main() {
 
 type JobList map[string]Job
 
+type Manager struct {
+	jList JobList
+	jLock map[string]string
+	mutex *sync.Mutex
+}
+
+func (m *Manager) ReadFromJobLock(template string) (string, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	v, ok := m.jLock[template]
+	return v, ok
+}
+
+func (m *Manager) WriteToJobLock(template, state string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.jLock[template] = state
+}
+
+func (m *Manager) DeleteFromJobLock(template string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	delete(m.jLock, template)
+}
+
+func (m *Manager) NameFromJob(j Job) (string, error) {
+	for k, v := range m.jList {
+		if v.Equal(j) {
+			return k, nil
+		}
+	}
+
+	return "", fmt.Errorf("Job is not in job list")
+}
+
 type Job struct {
 	Cron        string
 	Template    string
@@ -86,18 +127,29 @@ type Job struct {
 	Namespace   string
 }
 
+func (j Job) Equal(job Job) bool {
+	return j.Cron == job.Cron &&
+		j.Template == job.Template &&
+		j.Description == job.Description &&
+		j.Args == job.Args &&
+		j.Namespace == job.Namespace
+}
+
 func (j Job) Run() {
-	if _, ok := jobLock[j.Template]; ok {
-		nErr := fmt.Errorf("Unable to start new job (%s) because it is already running", j.Description)
-		honeybadger.Notify(nErr, honeybadger.Fingerprint{fmt.Sprintf("%d", time.Now().Unix())})
-		log.Println(nErr)
+	jobName, err := manager.NameFromJob(j)
+	if err != nil {
+		log.Printf()
+		return
+	}
+
+	if _, ok := manager.ReadFromJobLock(jobName); ok {
+		log.Printf("Unable to start new job (%s) because it is already running\n", j.Description)
 		return
 	}
 	log.Println("Running", j.Description)
 
-	//TODO not thread safe
-	jobLock[j.Template] = "started"
-	defer delete(jobLock, j.Template)
+	manager.WriteToJobLock(jobName, "started")
+	defer manager.DeleteFromJobLock(jobName)
 
 	if err := createTaskPod(j); err != nil {
 		nErr := fmt.Errorf("Failed to create task pod for job %s, error: %v", j.Description, err)

--- a/kube-scheduler.go
+++ b/kube-scheduler.go
@@ -11,9 +11,9 @@ import (
 	"os/signal"
 	"time"
 
+	honeybadger "github.com/honeybadger-io/honeybadger-go"
 	"github.com/joho/godotenv"
 	"github.com/robfig/cron"
-	"github.com/smeriwether/honeybadger-go"
 	kube "github.com/wearemolecule/kubeclient"
 	"golang.org/x/build/kubernetes/api"
 	"golang.org/x/net/context"
@@ -144,7 +144,7 @@ func createTaskPod(j Job) error {
 		podStatus := status.Pod.Status
 		if podStatus.Phase == "Failed" {
 			_ = kubeClient.DeletePod(ctx, newPod.Namespace, newPod.Name)
-			return errors.New(fmt.Sprintf("Task pod failed.\n%v", err))
+			return errors.New(fmt.Sprintf("Task pod %s in namespace %s failed.", newPod.Name, newPod.Namespace))
 		}
 		if podStatus.Phase == "Succeeded" {
 			if logs, err := kubeClient.PodLog(ctx, newPod.Namespace, newPod.Name); err != nil {


### PR DESCRIPTION
2 main changes:
- I added a `Manager` so we can have concurrent read/write access to the job-lock (this program is very concurrent) 
- The job-lock was using the job template as the lock key but that actually isn't unique to each job so we were seeing a lot of "can't start already running" errors so the lock key is now the job name which is unique (or should be unique).
